### PR TITLE
CI: ensure pytest installed for integration workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          # ensure pytest is available (requirements.txt may not list it)
+          python -m pip install pytest -q
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
Install pytest explicitly in the integration workflow so runner can execute tests.